### PR TITLE
Develop/v0.2.1: fix circular import error and the issue of type checking for `task_def_name`

### DIFF
--- a/omagent-core/src/omagent_core/engine/worker/base.py
+++ b/omagent-core/src/omagent_core/engine/worker/base.py
@@ -22,7 +22,6 @@ from omagent_core.engine.http.models.task import Task
 from omagent_core.engine.http.models.task_result import TaskResult
 from omagent_core.engine.http.models.task_result_status import TaskResultStatus
 from omagent_core.engine.worker.exception import NonRetryableException
-from omagent_core.engine.workflow.task.simple_task import SimpleTask
 
 
 ExecuteTaskFunction = Callable[[Union[Task, object]], Union[TaskResult, object]]

--- a/omagent-core/src/omagent_core/engine/workflow/task/simple_task.py
+++ b/omagent-core/src/omagent_core/engine/workflow/task/simple_task.py
@@ -1,4 +1,5 @@
 from typing_extensions import Self
+from typing import Type
 
 from omagent_core.engine.workflow.task.task import TaskInterface
 from omagent_core.engine.workflow.task.task_type import TaskType
@@ -15,7 +16,7 @@ class SimpleTask(TaskInterface):
 
 
 def simple_task(task_def_name: str|Type[BaseWorker], task_reference_name: str, inputs: dict[str, object] = {}) -> TaskInterface:
-    if issubclass(task_def_name, BaseWorker):
+    if isinstance(task_def_name, type) and issubclass(task_def_name, BaseWorker):
         task_def_name = task_def_name.name
     task = SimpleTask(task_def_name=task_def_name, task_reference_name=task_reference_name)
     task.input_parameters.update(inputs)


### PR DESCRIPTION
1. Fix circular import error
2. Fix the issue of type checking for `task_def_name`