### PR TITLE
Add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ OmAgent is python library for building multimodal language agents with ease. We 
  - Native multimodal interaction support include VLM models, real-time API, computer vision models, mobile connection and etc.   
  - A suite of state-of-the-art unimodal and multimodal agent algorithms that goes beyond simple LLM reasoning, e.g. ReAct, CoT, SC-Cot etc.   
  - Supports local deployment of models. You can deploy your own models locally by using Ollama[Ollama](./docs/concepts/models/Ollama.md) or [LocalAI](./examples/video_understanding/docs/local-ai.md).
+ - Supports multiple cloud LLM providers including OpenAI, Azure OpenAI, and [MiniMax](./docs/concepts/models/MiniMax.md) (M2.7/M2.5 models with up to 1M context).
  - Fully distributed architecture, supports custom scaling. Also supports Lite mode, eliminating the need for middleware deployment.
 
 
@@ -63,6 +64,12 @@ The container.yaml file is a configuration file that manages dependencies and se
    export custom_openai_endpoint="your_openai_endpoint"
    ```
    You can use a locally deployed Ollama to call your own language model. The tutorial is [here](docs/concepts/models/Ollama.md).
+
+   You can also use [MiniMax](docs/concepts/models/MiniMax.md) as your LLM provider:
+   ```bash
+   export MINIMAX_API_KEY="your_minimax_api_key"
+   ```
+   Then use `configs/llms/minimax.yml` instead of `gpt.yml`.
 
 ### Run the demo
 

--- a/docs/concepts/models/MiniMax.md
+++ b/docs/concepts/models/MiniMax.md
@@ -1,0 +1,90 @@
+# MiniMax
+
+[MiniMax](https://www.minimax.io/) provides large language models accessible via an OpenAI-compatible API. OmAgent supports MiniMax as a first-class LLM provider through the `MiniMaxLLM` class.
+
+## Supported Models
+
+| Model | Context Window | Description |
+|-------|---------------|-------------|
+| MiniMax-M2.7 | 1M tokens | Latest flagship model |
+| MiniMax-M2.7-highspeed | 1M tokens | High-speed variant of M2.7 |
+| MiniMax-M2.5 | 204K tokens | Previous generation model |
+| MiniMax-M2.5-highspeed | 204K tokens | High-speed variant of M2.5 |
+
+## Setup
+
+1. Get your API key from [MiniMax Platform](https://platform.minimax.chat/).
+2. Set the environment variable:
+   ```bash
+   export MINIMAX_API_KEY="your_minimax_api_key"
+   ```
+
+## Configuration
+
+### YAML Configuration
+
+Create a YAML config file (e.g., `configs/llms/minimax.yml`):
+
+```yaml
+name: MiniMaxLLM
+model_id: MiniMax-M2.7
+api_key: ${env| MINIMAX_API_KEY}
+endpoint: https://api.minimax.io/v1
+temperature: 0
+```
+
+### Python Configuration
+
+```python
+from omagent_core.models.llms.minimax_llm import MiniMaxLLM
+
+llm = MiniMaxLLM(
+    model_id="MiniMax-M2.7",
+    api_key="your_api_key",
+    temperature=0,
+)
+```
+
+### Using with BaseLLMBackend
+
+```python
+from typing import List
+from pydantic import Field
+from omagent_core.models.llms.base import BaseLLMBackend
+from omagent_core.models.llms.minimax_llm import MiniMaxLLM
+from omagent_core.models.llms.prompt.prompt import PromptTemplate
+from omagent_core.models.llms.prompt.parser import StrParser
+
+class MyAgent(BaseLLMBackend):
+    prompts: List[PromptTemplate] = Field(
+        default=[
+            PromptTemplate.from_template("You are a helpful assistant.", role="system"),
+            PromptTemplate.from_template("{{instruction}}", role="user"),
+        ]
+    )
+    llm: MiniMaxLLM = {
+        "name": "MiniMaxLLM",
+        "model_id": "MiniMax-M2.7",
+        "api_key": "your_api_key",
+    }
+    output_parser: StrParser = StrParser()
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model_id` | str | `MiniMax-M2.7` | The model to use |
+| `api_key` | str | `$MINIMAX_API_KEY` | Your MiniMax API key |
+| `endpoint` | str | `https://api.minimax.io/v1` | API endpoint URL |
+| `temperature` | float | `0.7` | Sampling temperature (0-1.0) |
+| `top_p` | float | `1.0` | Top-p sampling parameter |
+| `max_tokens` | int | `2048` | Maximum tokens to generate |
+| `stream` | bool | `false` | Enable streaming responses |
+| `response_format` | str | `text` | Response format (`text` or `json_object`) |
+
+## Notes
+
+- Temperature is automatically clamped to the [0, 1.0] range.
+- The MiniMax API is OpenAI-compatible, so it works seamlessly with the OpenAI SDK.
+- Think tags (`<think>...</think>`) in model responses are automatically stripped.

--- a/examples/step1_simpleVQA/configs/llms/minimax.yml
+++ b/examples/step1_simpleVQA/configs/llms/minimax.yml
@@ -1,0 +1,5 @@
+name: MiniMaxLLM
+model_id: MiniMax-M2.7
+api_key: ${env| MINIMAX_API_KEY}
+endpoint: https://api.minimax.io/v1
+temperature: 0

--- a/omagent-core/src/omagent_core/models/llms/minimax_llm.py
+++ b/omagent-core/src/omagent_core/models/llms/minimax_llm.py
@@ -1,0 +1,251 @@
+import os
+import re
+import sysconfig
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+import geocoder
+from openai import AsyncOpenAI, OpenAI
+from pydantic import Field
+
+from omagent_core.models.llms.base import BaseLLM
+from omagent_core.models.llms.schemas import Content, Message
+from omagent_core.utils.registry import registry
+
+BASIC_SYS_PROMPT = """You are an intelligent agent that can help in many regions.
+Flowing are some basic information about your working environment, please try your best to answer the questions based on them if needed.
+Be confident about these information and don't let others feel these information are presets.
+Be concise.
+---BASIC INFORMATION---
+Current Datetime: {}
+Region: {}
+Operating System: {}"""
+
+# MiniMax supported models and their context window sizes
+MINIMAX_MODELS = {
+    "MiniMax-M2.7": 1048576,        # 1M context
+    "MiniMax-M2.7-highspeed": 1048576,  # 1M context
+    "MiniMax-M2.5": 204800,         # 204K context
+    "MiniMax-M2.5-highspeed": 204800,   # 204K context
+}
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+@registry.register_llm()
+class MiniMaxLLM(BaseLLM):
+    """MiniMax LLM provider using OpenAI-compatible API.
+
+    MiniMax provides large language models accessible via an OpenAI-compatible
+    API endpoint. Supported models include MiniMax-M2.7, MiniMax-M2.7-highspeed,
+    MiniMax-M2.5, and MiniMax-M2.5-highspeed.
+
+    Configuration example (YAML):
+        name: MiniMaxLLM
+        model_id: MiniMax-M2.7
+        api_key: ${env| MINIMAX_API_KEY}
+        temperature: 0
+    """
+
+    model_id: str = Field(
+        default=os.getenv("MINIMAX_MODEL_ID", "MiniMax-M2.7"),
+        description="The model id of MiniMax LLM",
+    )
+    api_key: str = Field(
+        default=os.getenv("MINIMAX_API_KEY"),
+        description="The api key of MiniMax",
+    )
+    endpoint: str = Field(
+        default=os.getenv("MINIMAX_ENDPOINT", MINIMAX_API_BASE),
+        description="The endpoint of MiniMax LLM service",
+    )
+    temperature: float = Field(
+        default=0.7,
+        description="The temperature of LLM, must be in [0, 1.0]",
+    )
+    top_p: float = Field(
+        default=1.0,
+        description="The top p of LLM",
+    )
+    stream: bool = Field(default=False, description="Whether to stream the response")
+    max_tokens: int = Field(default=2048, description="The max tokens of LLM")
+    use_default_sys_prompt: bool = Field(
+        default=True, description="Whether to use the default system prompt"
+    )
+    response_format: Optional[Union[dict, str]] = Field(
+        default="text", description="The response format"
+    )
+    n: int = Field(default=1, description="The number of responses to generate")
+    stop: Union[str, List[str], None] = Field(
+        default=None, description="Specifies stop sequences"
+    )
+    stream_options: Optional[dict] = Field(
+        default=None, description="Configuration options for streaming responses"
+    )
+    tools: Optional[List[dict]] = Field(
+        default=None, description="A list of function tools the model can call"
+    )
+    tool_choice: Optional[str] = Field(
+        default="none",
+        description="Controls which tool is called by the model",
+    )
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        protected_namespaces = ()
+        extra = "allow"
+
+    def _clamp_temperature(self, temperature: float) -> float:
+        """Clamp temperature to MiniMax's accepted range [0, 1.0]."""
+        return max(0.0, min(1.0, temperature))
+
+    def check_response_format(self) -> None:
+        if isinstance(self.response_format, str):
+            if self.response_format == "text":
+                self.response_format = {"type": "text"}
+            elif self.response_format == "json_object":
+                self.response_format = {"type": "json_object"}
+        elif isinstance(self.response_format, dict):
+            for key, value in self.response_format.items():
+                if key not in ["type"]:
+                    raise ValueError(f"Invalid response format key: {key}")
+                if key == "type":
+                    if value not in ["text", "json_object"]:
+                        raise ValueError(f"Invalid response format value: {value}")
+        else:
+            raise ValueError(f"Invalid response format: {self.response_format}")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.temperature = self._clamp_temperature(self.temperature)
+        self.check_response_format()
+        self.client = OpenAI(api_key=self.api_key, base_url=self.endpoint)
+        self.aclient = AsyncOpenAI(api_key=self.api_key, base_url=self.endpoint)
+
+    def _strip_think_tags(self, content: str) -> str:
+        """Strip <think>...</think> tags from model response.
+
+        If stripping would result in empty content, returns the original
+        content with only the tags removed (preserving inner text).
+        """
+        if content is None:
+            return content
+        stripped = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
+        if stripped:
+            return stripped
+        # If all content was inside think tags, remove tags but keep inner text
+        fallback = re.sub(r"</?think>", "", content).strip()
+        return fallback if fallback else content
+
+    def _call(self, records: List[Message], **kwargs) -> Dict:
+        if self.api_key is None or self.api_key == "":
+            raise ValueError("api_key is required")
+
+        messages = self._msg2req(records)
+        temperature = self._clamp_temperature(
+            kwargs.get("temperature", self.temperature)
+        )
+
+        res = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=kwargs.get("max_tokens", self.max_tokens),
+            response_format=kwargs.get("response_format", self.response_format),
+            tools=kwargs.get("tools", None),
+            tool_choice=kwargs.get("tool_choice", None),
+            stream=kwargs.get("stream", self.stream),
+            n=kwargs.get("n", self.n),
+            top_p=kwargs.get("top_p", self.top_p),
+            stop=kwargs.get("stop", self.stop),
+            stream_options=kwargs.get("stream_options", self.stream_options),
+        )
+
+        if kwargs.get("stream", self.stream):
+            return res
+        else:
+            result = res.model_dump()
+            # Strip think tags from response content
+            for choice in result.get("choices", []):
+                msg = choice.get("message", {})
+                if msg.get("content"):
+                    msg["content"] = self._strip_think_tags(msg["content"])
+            return result
+
+    async def _acall(self, records: List[Message], **kwargs) -> Dict:
+        if self.api_key is None or self.api_key == "":
+            raise ValueError("api_key is required")
+
+        messages = self._msg2req(records)
+        temperature = self._clamp_temperature(
+            kwargs.get("temperature", self.temperature)
+        )
+
+        res = await self.aclient.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=kwargs.get("max_tokens", self.max_tokens),
+            response_format=kwargs.get("response_format", self.response_format),
+            tools=kwargs.get("tools", None),
+            n=kwargs.get("n", self.n),
+            top_p=kwargs.get("top_p", self.top_p),
+            stop=kwargs.get("stop", self.stop),
+            stream_options=kwargs.get("stream_options", self.stream_options),
+        )
+
+        result = res.model_dump()
+        # Strip think tags from response content
+        for choice in result.get("choices", []):
+            msg = choice.get("message", {})
+            if msg.get("content"):
+                msg["content"] = self._strip_think_tags(msg["content"])
+        return result
+
+    def _msg2req(self, records: List[Message]) -> list:
+        def get_content(msg: List[Content] | Content) -> List[dict] | str:
+            if isinstance(msg, list):
+                return [c.model_dump(exclude_none=True) for c in msg]
+            elif isinstance(msg, Content) and msg.type == "text":
+                return msg.text
+            elif isinstance(msg, Content) and msg.type == "image_url":
+                return [msg.model_dump(exclude_none=True)]
+            else:
+                raise ValueError("Invalid message type")
+
+        messages = [
+            {"role": message.role, "content": get_content(message.content)}
+            for message in records
+        ]
+        if self.use_default_sys_prompt:
+            messages = [self._generate_default_sys_prompt()] + messages
+        return messages
+
+    def _generate_default_sys_prompt(self) -> Dict:
+        loc = self._get_location()
+        os_info = self._get_linux_distribution()
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        prompt_str = BASIC_SYS_PROMPT.format(current_time, loc, os_info)
+        return {"role": "system", "content": prompt_str}
+
+    def _get_linux_distribution(self) -> str:
+        platform = sysconfig.get_platform()
+        if "linux" in platform:
+            if os.path.exists("/etc/lsb-release"):
+                with open("/etc/lsb-release", "r") as f:
+                    for line in f:
+                        if line.startswith("DISTRIB_DESCRIPTION="):
+                            return line.split("=")[1].strip()
+            elif os.path.exists("/etc/os-release"):
+                with open("/etc/os-release", "r") as f:
+                    for line in f:
+                        if line.startswith("PRETTY_NAME="):
+                            return line.split("=")[1].strip()
+        return platform
+
+    def _get_location(self) -> str:
+        g = geocoder.ip("me")
+        if g.ok:
+            return g.city + "," + g.country
+        else:
+            return "unknown"

--- a/tests/test_minimax_llm.py
+++ b/tests/test_minimax_llm.py
@@ -1,0 +1,360 @@
+"""Unit tests for MiniMaxLLM provider."""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add the source path so we can import omagent_core
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "omagent-core",
+        "src",
+    ),
+)
+
+from omagent_core.models.llms.minimax_llm import (
+    MINIMAX_API_BASE,
+    MINIMAX_MODELS,
+    MiniMaxLLM,
+)
+from omagent_core.models.llms.schemas import Content, Message, Role
+
+
+class TestMiniMaxLLMConfig(unittest.TestCase):
+    """Test MiniMaxLLM configuration and initialization."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_default_config(self, mock_async, mock_sync):
+        """Test default configuration values."""
+        llm = MiniMaxLLM(api_key="test-key-123")
+        self.assertEqual(llm.model_id, "MiniMax-M2.7")
+        self.assertEqual(llm.endpoint, MINIMAX_API_BASE)
+        self.assertAlmostEqual(llm.temperature, 0.7)
+        self.assertEqual(llm.max_tokens, 2048)
+        self.assertFalse(llm.stream)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_custom_config(self, mock_async, mock_sync):
+        """Test custom configuration values."""
+        llm = MiniMaxLLM(
+            api_key="test-key",
+            model_id="MiniMax-M2.5-highspeed",
+            temperature=0.3,
+            max_tokens=4096,
+            stream=True,
+        )
+        self.assertEqual(llm.model_id, "MiniMax-M2.5-highspeed")
+        self.assertAlmostEqual(llm.temperature, 0.3)
+        self.assertEqual(llm.max_tokens, 4096)
+        self.assertTrue(llm.stream)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_client_initialization(self, mock_async_cls, mock_sync_cls):
+        """Test that OpenAI clients are initialized with correct params."""
+        llm = MiniMaxLLM(api_key="test-key", endpoint="https://custom.api.com/v1")
+        mock_sync_cls.assert_called_once_with(
+            api_key="test-key", base_url="https://custom.api.com/v1"
+        )
+        mock_async_cls.assert_called_once_with(
+            api_key="test-key", base_url="https://custom.api.com/v1"
+        )
+
+
+class TestTemperatureClamping(unittest.TestCase):
+    """Test temperature clamping behavior."""
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_temperature_zero(self, mock_async, mock_sync):
+        """Test temperature=0 is accepted."""
+        llm = MiniMaxLLM(api_key="test-key", temperature=0)
+        self.assertAlmostEqual(llm.temperature, 0.0)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_temperature_one(self, mock_async, mock_sync):
+        """Test temperature=1.0 is accepted."""
+        llm = MiniMaxLLM(api_key="test-key", temperature=1.0)
+        self.assertAlmostEqual(llm.temperature, 1.0)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_temperature_clamp_high(self, mock_async, mock_sync):
+        """Test temperature > 1.0 is clamped to 1.0."""
+        llm = MiniMaxLLM(api_key="test-key", temperature=2.0)
+        self.assertAlmostEqual(llm.temperature, 1.0)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_temperature_clamp_negative(self, mock_async, mock_sync):
+        """Test negative temperature is clamped to 0."""
+        llm = MiniMaxLLM(api_key="test-key", temperature=-0.5)
+        self.assertAlmostEqual(llm.temperature, 0.0)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_temperature_clamp_in_call(self, mock_async, mock_sync):
+        """Test temperature clamping during _call kwargs."""
+        llm = MiniMaxLLM(api_key="test-key", temperature=0.5)
+        clamped = llm._clamp_temperature(1.5)
+        self.assertAlmostEqual(clamped, 1.0)
+        clamped = llm._clamp_temperature(-1.0)
+        self.assertAlmostEqual(clamped, 0.0)
+
+
+class TestThinkTagStripping(unittest.TestCase):
+    """Test think tag stripping from model responses."""
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def setUp(self, mock_async, mock_sync):
+        self.llm = MiniMaxLLM(api_key="test-key")
+
+    def test_strip_think_tags(self):
+        """Test basic think tag stripping."""
+        content = "<think>internal reasoning</think>The answer is 42."
+        result = self.llm._strip_think_tags(content)
+        self.assertEqual(result, "The answer is 42.")
+
+    def test_strip_multiline_think_tags(self):
+        """Test multiline think tag stripping."""
+        content = "<think>\nstep 1\nstep 2\nstep 3\n</think>\nFinal answer."
+        result = self.llm._strip_think_tags(content)
+        self.assertEqual(result, "Final answer.")
+
+    def test_no_think_tags(self):
+        """Test content without think tags is unchanged."""
+        content = "Hello, world!"
+        result = self.llm._strip_think_tags(content)
+        self.assertEqual(result, "Hello, world!")
+
+    def test_none_content(self):
+        """Test None content returns None."""
+        result = self.llm._strip_think_tags(None)
+        self.assertIsNone(result)
+
+    def test_empty_think_tags(self):
+        """Test empty think tags are stripped."""
+        content = "<think></think>Result."
+        result = self.llm._strip_think_tags(content)
+        self.assertEqual(result, "Result.")
+
+
+class TestResponseFormat(unittest.TestCase):
+    """Test response format validation."""
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_text_format(self, mock_async, mock_sync):
+        """Test text response format."""
+        llm = MiniMaxLLM(api_key="test-key", response_format="text")
+        self.assertEqual(llm.response_format, {"type": "text"})
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_json_format(self, mock_async, mock_sync):
+        """Test json_object response format."""
+        llm = MiniMaxLLM(api_key="test-key", response_format="json_object")
+        self.assertEqual(llm.response_format, {"type": "json_object"})
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_dict_format(self, mock_async, mock_sync):
+        """Test dict response format."""
+        llm = MiniMaxLLM(api_key="test-key", response_format={"type": "json_object"})
+        self.assertEqual(llm.response_format, {"type": "json_object"})
+
+
+class TestMessageConversion(unittest.TestCase):
+    """Test message conversion to API format."""
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def setUp(self, mock_async, mock_sync):
+        self.llm = MiniMaxLLM(api_key="test-key", use_default_sys_prompt=False)
+
+    def test_simple_text_message(self):
+        """Test simple text message conversion."""
+        messages = [Message.user("Hello")]
+        result = self.llm._msg2req(messages)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["role"], Role.USER)
+        self.assertEqual(result[0]["content"], "Hello")
+
+    def test_system_message(self):
+        """Test system message conversion."""
+        messages = [
+            Message.system("You are helpful"),
+            Message.user("Hi"),
+        ]
+        result = self.llm._msg2req(messages)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["role"], Role.SYSTEM)
+        self.assertEqual(result[1]["role"], Role.USER)
+
+    def test_default_sys_prompt(self):
+        """Test default system prompt is prepended."""
+        llm = self.__class__._create_llm(use_default_sys_prompt=True)
+        messages = [Message.user("Hi")]
+        result = llm._msg2req(messages)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["role"], "system")
+        self.assertIn("Current Datetime", result[0]["content"])
+
+    @classmethod
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def _create_llm(cls, mock_async=None, mock_sync=None, **kwargs):
+        return MiniMaxLLM(api_key="test-key", **kwargs)
+
+
+class TestCallMethod(unittest.TestCase):
+    """Test the _call method."""
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_call_success(self, mock_async, mock_sync):
+        """Test successful _call."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "choices": [
+                {
+                    "message": {"content": "Hello! How can I help?", "role": "assistant"},
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_sync.return_value = mock_client
+
+        llm = MiniMaxLLM(api_key="test-key", use_default_sys_prompt=False)
+        messages = [Message.user("Hello")]
+        result = llm._call(messages)
+
+        self.assertEqual(result["choices"][0]["message"]["content"], "Hello! How can I help?")
+        mock_client.chat.completions.create.assert_called_once()
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_call_with_think_tags(self, mock_async, mock_sync):
+        """Test _call strips think tags from response."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "<think>reasoning here</think>The answer is 42.",
+                        "role": "assistant",
+                    },
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_sync.return_value = mock_client
+
+        llm = MiniMaxLLM(api_key="test-key", use_default_sys_prompt=False)
+        messages = [Message.user("What is 6*7?")]
+        result = llm._call(messages)
+
+        self.assertEqual(result["choices"][0]["message"]["content"], "The answer is 42.")
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_call_no_api_key(self, mock_async, mock_sync):
+        """Test _call raises error without api key."""
+        llm = MiniMaxLLM(api_key="", use_default_sys_prompt=False)
+        messages = [Message.user("Hello")]
+        with self.assertRaises(ValueError):
+            llm._call(messages)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_call_streaming(self, mock_async, mock_sync):
+        """Test _call returns stream object when streaming."""
+        mock_client = MagicMock()
+        mock_stream = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_stream
+        mock_sync.return_value = mock_client
+
+        llm = MiniMaxLLM(api_key="test-key", stream=True, use_default_sys_prompt=False)
+        messages = [Message.user("Hello")]
+        result = llm._call(messages)
+
+        self.assertEqual(result, mock_stream)
+
+    @patch("omagent_core.models.llms.minimax_llm.OpenAI")
+    @patch("omagent_core.models.llms.minimax_llm.AsyncOpenAI")
+    def test_call_temperature_clamping(self, mock_async, mock_sync):
+        """Test that temperature is clamped in _call."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "choices": [{"message": {"content": "ok", "role": "assistant"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_sync.return_value = mock_client
+
+        llm = MiniMaxLLM(api_key="test-key", use_default_sys_prompt=False)
+        messages = [Message.user("Hello")]
+        llm._call(messages, temperature=5.0)
+
+        call_kwargs = mock_client.chat.completions.create.call_args
+        self.assertAlmostEqual(call_kwargs.kwargs["temperature"], 1.0)
+
+
+class TestModelConstants(unittest.TestCase):
+    """Test model constants and metadata."""
+
+    def test_minimax_models_defined(self):
+        """Test that all MiniMax models are defined."""
+        self.assertIn("MiniMax-M2.7", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.7-highspeed", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.5", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.5-highspeed", MINIMAX_MODELS)
+
+    def test_model_context_sizes(self):
+        """Test model context window sizes."""
+        self.assertEqual(MINIMAX_MODELS["MiniMax-M2.7"], 1048576)
+        self.assertEqual(MINIMAX_MODELS["MiniMax-M2.7-highspeed"], 1048576)
+        self.assertEqual(MINIMAX_MODELS["MiniMax-M2.5"], 204800)
+        self.assertEqual(MINIMAX_MODELS["MiniMax-M2.5-highspeed"], 204800)
+
+    def test_api_base_url(self):
+        """Test MiniMax API base URL."""
+        self.assertEqual(MINIMAX_API_BASE, "https://api.minimax.io/v1")
+
+
+class TestRegistration(unittest.TestCase):
+    """Test registry integration."""
+
+    def test_llm_registered(self):
+        """Test that MiniMaxLLM is registered in the registry."""
+        from omagent_core.utils.registry import registry
+
+        llm_cls = registry.get_llm("MiniMaxLLM")
+        self.assertIsNotNone(llm_cls)
+        self.assertEqual(llm_cls.__name__, "MiniMaxLLM")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_llm_integration.py
+++ b/tests/test_minimax_llm_integration.py
@@ -1,0 +1,95 @@
+"""Integration tests for MiniMaxLLM provider.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+Skip with: pytest -m "not integration"
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+
+# Add the source path so we can import omagent_core
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "omagent-core",
+        "src",
+    ),
+)
+
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "")
+SKIP_REASON = "MINIMAX_API_KEY not set"
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, SKIP_REASON)
+class TestMiniMaxLLMIntegration(unittest.TestCase):
+    """Integration tests that hit the real MiniMax API."""
+
+    def setUp(self):
+        from omagent_core.models.llms.minimax_llm import MiniMaxLLM
+
+        self.llm = MiniMaxLLM(
+            api_key=MINIMAX_API_KEY,
+            model_id="MiniMax-M2.7",
+            temperature=0,
+            max_tokens=100,
+            use_default_sys_prompt=False,
+        )
+
+    def test_simple_completion(self):
+        """Test a simple chat completion."""
+        from omagent_core.models.llms.schemas import Message
+
+        messages = [
+            Message.system("You are a helpful assistant. Reply concisely. Do not use think tags."),
+            Message.user("What is 2+2? Reply with just the number."),
+        ]
+        result = self.llm._call(messages)
+
+        self.assertIn("choices", result)
+        self.assertTrue(len(result["choices"]) > 0)
+        content = result["choices"][0]["message"]["content"]
+        self.assertIsNotNone(content)
+        self.assertTrue(len(content) > 0)
+        self.assertIn("4", content)
+
+    def test_response_has_usage(self):
+        """Test that response includes token usage information."""
+        from omagent_core.models.llms.schemas import Message
+
+        messages = [
+            Message.system("Reply concisely. Do not use think tags."),
+            Message.user("Say hello."),
+        ]
+        result = self.llm._call(messages)
+
+        self.assertIn("usage", result)
+        usage = result["usage"]
+        self.assertIn("prompt_tokens", usage)
+        self.assertIn("completion_tokens", usage)
+        self.assertIn("total_tokens", usage)
+        self.assertGreater(usage["total_tokens"], 0)
+
+    def test_async_completion(self):
+        """Test async chat completion."""
+        from omagent_core.models.llms.schemas import Message
+
+        messages = [
+            Message.system("You are a helpful assistant. Reply concisely. Do not use think tags."),
+            Message.user("What is 3+5? Reply with just the number."),
+        ]
+
+        result = asyncio.run(self.llm._acall(messages))
+
+        self.assertIn("choices", result)
+        content = result["choices"][0]["message"]["content"]
+        self.assertIsNotNone(content)
+        self.assertTrue(len(content) > 0)
+        self.assertIn("8", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class LLM provider for OmAgent, following the existing BaseLLM + registry pattern.

### Changes

- **minimax_llm.py** - MiniMaxLLM class inheriting BaseLLM, registered via @registry.register_llm(). Uses OpenAI-compatible API with:
  - Temperature clamping to [0, 1.0] range
  - Automatic think tag stripping from responses
  - Sync (_call) and async (_acall) support
  - Streaming support
  - Response format validation (text / json_object)

- **Supported Models**: MiniMax-M2.7 (1M context), MiniMax-M2.7-highspeed, MiniMax-M2.5 (204K context), MiniMax-M2.5-highspeed

- **minimax.yml** - Example YAML config
- **MiniMax.md** - Full documentation with setup, config, and usage examples
- **README.md** - Added MiniMax to supported providers list
- **tests** - 28 unit tests + 3 integration tests (31 total)

### Usage

```yaml
name: MiniMaxLLM
model_id: MiniMax-M2.7
api_key: ${env| MINIMAX_API_KEY}
temperature: 0
```

## Test Plan

- [x] 28 unit tests pass (mocked API)
- [x] 3 integration tests pass (real MiniMax API)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniMax as a supported cloud LLM provider with full configuration and integration support

* **Documentation**
  * New MiniMax documentation page covering setup, supported models, configurable parameters, and usage examples
  * Updated README to document MiniMax provider alongside existing cloud providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->